### PR TITLE
add move_window feature

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -2,7 +2,7 @@
 detection_window_width = 320
 detection_window_height = 320
 circle_capture = True
-disable_move_window = False
+disable_move_window = True
 move_window_width  = 150
 move_window_height = 150
 

--- a/config.ini
+++ b/config.ini
@@ -2,6 +2,9 @@
 detection_window_width = 320
 detection_window_height = 320
 circle_capture = True
+disable_move_window = False
+move_window_width  = 150
+move_window_height = 150
 
 [Capture Methods]
 Bettercam_capture = False

--- a/logic/config_watcher.py
+++ b/logic/config_watcher.py
@@ -20,6 +20,10 @@ class Config():
         self.detection_window_width = int(self.config_Detection_window["detection_window_width"])
         self.detection_window_height = int(self.config_Detection_window["detection_window_height"])
         self.circle_capture = self.config_Detection_window.getboolean("circle_capture")
+        self.disable_move_window = self.config_Detection_window.getboolean("disable_move_window")
+        self.execution_window_width = int(self.config_Detection_window["execution_window_width"])
+        self.execution_window_height = int(self.config_Detection_window["execution_window_height"])
+
         # Capture Method mss
         self.config_mss_capture = self.config["Capture Methods"]
         self.mss_capture = self.config_mss_capture.getboolean("mss_capture")

--- a/logic/config_watcher.py
+++ b/logic/config_watcher.py
@@ -21,8 +21,8 @@ class Config():
         self.detection_window_height = int(self.config_Detection_window["detection_window_height"])
         self.circle_capture = self.config_Detection_window.getboolean("circle_capture")
         self.disable_move_window = self.config_Detection_window.getboolean("disable_move_window")
-        self.execution_window_width = int(self.config_Detection_window["execution_window_width"])
-        self.execution_window_height = int(self.config_Detection_window["execution_window_height"])
+        self.move_window_width = int(self.config_Detection_window["move_window_width"])
+        self.move_window_height = int(self.config_Detection_window["move_window_height"])
 
         # Capture Method mss
         self.config_mss_capture = self.config["Capture Methods"]

--- a/logic/frame_parser.py
+++ b/logic/frame_parser.py
@@ -42,9 +42,12 @@ class FrameParser:
         if target:
             if hotkeys_watcher.clss is None:
                 hotkeys_watcher.active_classes()
-            
+
             if target.cls in hotkeys_watcher.clss:
-                mouse.process_data((target.x, target.y, target.w, target.h, target.cls))
+                if cfg.disable_move_window:
+                    mouse.process_data((target.x, target.y, target.w, target.h, target.cls))
+                elif self.is_in_move_range(target.x, target.y):
+                    mouse.process_data((target.x, target.y, target.w, target.h, target.cls))
 
     def _visualize_frame(self, frame):
         if cfg.show_window or cfg.show_overlay:
@@ -114,6 +117,11 @@ class FrameParser:
         target_class = classes_tensor[nearest_idx].item()
 
         return Target(*target_data, target_class)
+
+    def is_in_move_range(self, target_x, target_y):
+        offset_x = abs(target_x - capture.screen_x_center)
+        offset_y = abs(target_y - capture.screen_y_center)
+        return offset_x <= cfg.execution_x and offset_y <= cfg.execution_y
 
     def get_arch(self):
         if cfg.AI_enable_AMD:

--- a/logic/frame_parser.py
+++ b/logic/frame_parser.py
@@ -121,7 +121,7 @@ class FrameParser:
     def is_in_move_range(self, target_x, target_y):
         offset_x = abs(target_x - capture.screen_x_center)
         offset_y = abs(target_y - capture.screen_y_center)
-        return offset_x <= cfg.execution_x and offset_y <= cfg.execution_y
+        return offset_x <= cfg.move_window_width and offset_y <= cfg.move_window_height
 
     def get_arch(self):
         if cfg.AI_enable_AMD:


### PR DESCRIPTION
Reasons:
1. Some high-risk game platforms (e.g. Tencent) may detect the distance you move, and you have to limit the distance you move the mouse.
At this time, you cannot simply  reduce the range of the detection window, because this will affect the recognition rate of the model.

2. For some pros, they just want to correct the "last centimeter" of aiming rather than a large range of mouse movement.

3. Unless the model is trained very well, the _find_nearest_target method does not always work well.